### PR TITLE
Fix not sending OS property in reponse to scan

### DIFF
--- a/src/back/Server.js
+++ b/src/back/Server.js
@@ -3,7 +3,8 @@ const net = require('net');
 const Requestee = require('./Requestee');
 const Sender = require('./Sender');
 const Receiver = require('./Receiver');
-const { PORT, OS, VERSION, STATE } = require('../defs');
+const { PORT, VERSION, STATE } = require('../defs');
+const { OS } = require('./defs');
 const { _getBroadcastIp } = require('./Network');
 const { splitHeader, MAX_HEADER_LEN, createItemArray, HEADER_END } = require('./Common');
 

--- a/src/back/defs.js
+++ b/src/back/defs.js
@@ -1,0 +1,3 @@
+const OS = require('os').platform();
+
+module.exports = { OS };


### PR DESCRIPTION
#21 has deleted `OS` property in `defs.js`.
I don't know why I did that, but maybe I cannot call `require('os')`, as the file is used by client,
so I had deleted the code without reconsidering thoroughly what it would cause in the future.

This is the source of the problem where tiShare mobile crashes when scanning desktop clients.