### PR TITLE
[#47] Show last modified date of files in `ItemView`

### DIFF
--- a/src/back/main.js
+++ b/src/back/main.js
@@ -110,8 +110,16 @@ app.on('window-all-closed', function () {
  */
 async function addDirectory (itemPath, ret) {
   try {
+    const {mtime} = await fs.stat(itemPath);
     const size = (await fs.readdir(itemPath)).length;
-    ret[path.basename(itemPath)] = {path: itemPath, name: path.basename(itemPath), dir: '.', type: 'directory', size: size};
+    ret[path.basename(itemPath)] = {
+      path: itemPath,
+      name: path.basename(itemPath),
+      dir: '.',
+      type: 'directory',
+      size,
+      mtime,
+    };
   } catch (err) {
     // Do nothing.
   }
@@ -120,8 +128,15 @@ async function addDirectory (itemPath, ret) {
 
 async function addFile (itemPath, ret) {
   try {
-    const size = (await fs.stat(itemPath)).size;
-    ret[path.basename(itemPath)] = {path: itemPath, name: path.basename(itemPath), dir: '.', type: 'file', size: size};
+    const {size, mtime} = await fs.stat(itemPath);
+    ret[path.basename(itemPath)] = {
+      path: itemPath,
+      name: path.basename(itemPath),
+      dir: '.',
+      type: 'file',
+      size,
+      mtime,
+    };
   } catch (err) {
     // Do nothing.
   }

--- a/src/front/component/Item.jsx
+++ b/src/front/component/Item.jsx
@@ -1,5 +1,6 @@
 import {useState} from 'react';
 import * as DEFS from '../../defs';
+import useFormatDate from '../hook/useFormatDate';
 
 const {printSize, WELL_KNOWN_IMAGE_EXTENSIONS} = DEFS.default;
 
@@ -15,6 +16,7 @@ const {printSize, WELL_KNOWN_IMAGE_EXTENSIONS} = DEFS.default;
  * @param {string} props.item.name
  * @param {string} props.item.type
  * @param {string} props.item.path
+ * @param {Date | undefined} props.item.mtime
  * @param {size} props.item.number
  */
 const Item = ({item, items, checkAll, lastClick, setLastClick, checked, setChecked}) => {
@@ -23,6 +25,7 @@ const Item = ({item, items, checkAll, lastClick, setLastClick, checked, setCheck
     WELL_KNOWN_IMAGE_EXTENSIONS.some(ext => item.path.toLowerCase().endsWith(`.${ext}`))
   );
   const onThumbnailError = () => setIsThumbnailVisible(false);
+  const formattedMtime = useFormatDate(item.mtime);
 
   /** @type React.MouseEventHandler<HTMLInputElement> */
   const onCheckboxClick = (e) => {
@@ -81,6 +84,7 @@ const Item = ({item, items, checkAll, lastClick, setLastClick, checked, setCheck
       </div>
       <div className='ItemProperty'>
         {(item.type === 'directory' ? item.size + ' items' : printSize(item.size))}
+        {!!formattedMtime && ('｜' + formattedMtime)}
       </div>
     </div>
     <div className='ItemCheck'>

--- a/src/front/component/Item.jsx
+++ b/src/front/component/Item.jsx
@@ -1,6 +1,6 @@
 import {useState} from 'react';
 import * as DEFS from '../../defs';
-import useFormatDate from '../hook/useFormatDate';
+import useFormattedDate from '../hook/useFormattedDate';
 
 const {printSize, WELL_KNOWN_IMAGE_EXTENSIONS} = DEFS.default;
 
@@ -25,7 +25,7 @@ const Item = ({item, items, checkAll, lastClick, setLastClick, checked, setCheck
     WELL_KNOWN_IMAGE_EXTENSIONS.some(ext => item.path.toLowerCase().endsWith(`.${ext}`))
   );
   const onThumbnailError = () => setIsThumbnailVisible(false);
-  const formattedMtime = useFormatDate(item.mtime);
+  const formattedMtime = useFormattedDate(item.mtime);
 
   /** @type React.MouseEventHandler<HTMLInputElement> */
   const onCheckboxClick = (e) => {

--- a/src/front/hook/useFormatDate.js
+++ b/src/front/hook/useFormatDate.js
@@ -1,0 +1,37 @@
+import {useMemo} from 'react';
+
+/**
+ * Format `Date` object into fancy string.
+ * 06-16-2024 pm 6:55
+ * @param {Date | undefined} date
+ * @returns {string}
+ */
+const useFormatDate = (date) => {
+  return useMemo(() => {
+    if (!date) {
+      return '';
+    }
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const amOrPm = date.getHours() >= 12 ? 'pm' : 'am';
+    const hour = date.getHours() % 12;
+    const minute = date.getMinutes();
+
+    /**
+     * Pad `value` of `number` type with zeros and return the string.
+     * @param {number} value
+     * @param {number} maxLength
+     * @returns {string}
+     */
+    const padStartZero = (value, maxLength) => {
+      return value.toString().padStart(maxLength, '0');
+    };
+
+    const formattedDate =
+      `${padStartZero(month, 2)}-${padStartZero(day, 2)}-${year} ${amOrPm} ${hour}:${minute}`;
+    return formattedDate;
+  }, [date]);
+};
+
+export default useFormatDate;

--- a/src/front/hook/useFormattedDate.js
+++ b/src/front/hook/useFormattedDate.js
@@ -15,7 +15,7 @@ const useFormattedDate = (date) => {
     const month = date.getMonth() + 1;
     const day = date.getDate();
     const amOrPm = date.getHours() >= 12 ? 'pm' : 'am';
-    const hour = date.getHours() % 12;
+    const hour = (date.getHours() % 12) + (date.getHours() % 12 === 0 ? 12 : 0);
     const minute = date.getMinutes();
 
     /**

--- a/src/front/hook/useFormattedDate.js
+++ b/src/front/hook/useFormattedDate.js
@@ -6,7 +6,7 @@ import {useMemo} from 'react';
  * @param {Date | undefined} date
  * @returns {string}
  */
-const useFormatDate = (date) => {
+const useFormattedDate = (date) => {
   return useMemo(() => {
     if (!date) {
       return '';
@@ -34,4 +34,4 @@ const useFormatDate = (date) => {
   }, [date]);
 };
 
-export default useFormatDate;
+export default useFormattedDate;


### PR DESCRIPTION
Closes #47 .

According to nodejs and mozilla docs,
inter-process communications in ElectronJS can handle `Date` objects as expected.

>Electron's IPC implementation uses the HTML standard [Structured Clone Algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) to serialize objects passed between processes, meaning that only certain types of objects can be passed through IPC channels.
>https://nodejs.org/docs/latest-v20.x/api/fs.html#statsmtime

>## Supported types
>### JavaScript types
>Array
>ArrayBuffer
>Boolean
>DataView
>Date
>https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#javascript_types

