### PR TITLE
Fix dev mode crash on linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@typescript-eslint/parser": "^8.17.0",
         "@vitejs/plugin-react": "^4.3.4",
         "concurrently": "^9.1.0",
-        "electron": "^33.2.1",
+        "electron": "^37.2.6",
         "electron-builder": "^25.1.8",
         "eslint": "^9.16.0",
         "eslint-plugin-react": "^7.37.2",
@@ -4375,15 +4375,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "33.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.2.1.tgz",
-      "integrity": "sha512-SG/nmSsK9Qg1p6wAW+ZfqU+AV8cmXMTIklUL18NnOKfZLlum4ZsDoVdmmmlL39ZmeCaq27dr7CgslRPahfoVJg==",
+      "version": "37.2.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.6.tgz",
+      "integrity": "sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -4499,23 +4499,6 @@
       "integrity": "sha512-vOzZS6uZwhhbkZbcRyiy99Wg+pYFV5hk+5YaECvx0+Z31NR3Tt5zS6dze2OepT6PCTzVzT0dIJItti+uAW5zmw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/electron/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -12708,31 +12691,14 @@
       }
     },
     "electron": {
-      "version": "33.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.2.1.tgz",
-      "integrity": "sha512-SG/nmSsK9Qg1p6wAW+ZfqU+AV8cmXMTIklUL18NnOKfZLlum4ZsDoVdmmmlL39ZmeCaq27dr7CgslRPahfoVJg==",
+      "version": "37.2.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.6.tgz",
+      "integrity": "sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "20.17.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-          "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~6.19.2"
-          }
-        },
-        "undici-types": {
-          "version": "6.19.8",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-          "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-          "dev": true
-        }
       }
     },
     "electron-builder": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@typescript-eslint/parser": "^8.17.0",
     "@vitejs/plugin-react": "^4.3.4",
     "concurrently": "^9.1.0",
-    "electron": "^33.2.1",
+    "electron": "^37.2.6",
     "electron-builder": "^25.1.8",
     "eslint": "^9.16.0",
     "eslint-plugin-react": "^7.37.2",

--- a/src/back/main.js
+++ b/src/back/main.js
@@ -1,11 +1,12 @@
 // Modules to control application life and create native browser window
-import {app, BrowserWindow, ipcMain, dialog, protocol, net} from 'electron';
+import {app, BrowserWindow, ipcMain, dialog, protocol, net, nativeImage} from 'electron';
 import fs from 'fs/promises';
 import path from 'path';
 import * as network from './Network.js';
 import Server from './Server.js';
 import Client from './Client.js';
 import Indexer from './Indexer.js';
+import {OS} from './defs.js';
 
 const isDev = !app.isPackaged;
 
@@ -51,10 +52,15 @@ function createMainWindow () {
   });
 
   if (isDev) {
-    console.log('Running in development');
     // When in development, run react start first.
-    // The main electron window will load the react webpage like below.
-    mainWindow.setIcon(path.join(import.meta.dirname, '../../public/icon.ico'));
+    // Then load the url from the main electron window.
+    console.log('Running in development');
+    // It seems like .icon is not supported in linux; it can't load image from the path.
+    // Use .icon file on win32 only.
+    const iconPath = nativeImage.createFromPath(path.join(
+      import.meta.dirname, OS === 'win32' ? '../../public/icon.ico' : '../../public/icon.png'
+    ));
+    mainWindow.setIcon(iconPath);
     mainWindow.loadURL('http://localhost:3000');
     mainWindow.maximize();
   }


### PR DESCRIPTION
This PR fixes the app not launching in dev mode, linux.
There are these two problems.

It cannot read `.ico` file. Changed the icon file to a `.png` file. But it does the icon file in dock panel.
I think the problem persist on Ubuntu 25.04: <https://github.com/electron/electron/issues/45335>

Second, it does not show the GUI in the window. I guess it cannot load from the vite server.
Updated electron and the problem is solved.
```shell
ERROR:network_service_instance_impl.cc(613)] Network service crashed, restarting service.
```
