### PR TITLE
Fix back eslint config and lint errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import globals from 'globals';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import reactPlugin from 'eslint-plugin-react';
 import tsParser from "@typescript-eslint/parser";
+import js from "@eslint/js";
 
 /** @type {import('eslint').Linter.Config.RulesRecord} */
 const globalRules = {
@@ -78,19 +79,17 @@ export default [
   },
   {
     name: 'back',
-    files: ['back/**/*.js'],
-    extends: ['eslint:recommended'],
+    files: ['src/back/**/*.js'],
     languageOptions: {
-      parserOptions: {
-        globals: {
-          ...globals.commonjs,
-          ...globals.node,
-          ...globals.mocha,
-        }
+      globals: {
+        ...globals.commonjs,
+        ...globals.node,
+        ...globals.mocha,
       }
     },
     rules: {
       ...globalRules,
+      ...js.configs.recommended.rules,
     }
   }
 ];

--- a/src/back/Client.js
+++ b/src/back/Client.js
@@ -82,7 +82,7 @@ class Client {
       }
       try {
         recvHeader = JSON.parse(ret.header);
-      } catch (err) {
+      } catch {
         // HEADER_END is met but is not JSON format.
         // Abort this suspicious connection.
         this.#handleNetworkErr(ind);
@@ -173,7 +173,7 @@ class Client {
       }
       try {
         recvHeader = JSON.parse(ret.header);
-      } catch (err) {
+      } catch {
         // HEADER_END is met but is not JSON format.
         // Abort this suspicious connection.
         this.#handleNetworkErr(ind);

--- a/src/back/Server.js
+++ b/src/back/Server.js
@@ -94,7 +94,7 @@ class Server {
         }
         try {
           recvHeader = JSON.parse(ret.header);
-        } catch (err) {
+        } catch {
           // HEADER_END is met but is not JSON format.
           // Abort and ignore this suspicious connection.
           this.#handleNetworkErr(ind);

--- a/src/back/back.test.js
+++ b/src/back/back.test.js
@@ -7,7 +7,7 @@ import Server from './Server.js';
 import Client from './Client.js';
 import {MAX_NUM_JOBS} from '../defs.js';
 import {getBroadcastIp, isLocalIp} from './Network.js';
-import {after, before} from 'mocha';
+import {after} from 'mocha';
 
 describe('Indexer', () => {
   const indexer = new Indexer(() => { }, () => { });

--- a/src/back/main.js
+++ b/src/back/main.js
@@ -143,7 +143,7 @@ async function addDirectory (itemPath, ret) {
       size,
       mtime,
     };
-  } catch (err) {
+  } catch {
     // Do nothing.
   }
   return;
@@ -164,7 +164,7 @@ async function addFile (itemPath, ret) {
       size,
       mtime,
     };
-  } catch (err) {
+  } catch {
     // Do nothing.
   }
   return;

--- a/src/back/task/Receiver.js
+++ b/src/back/task/Receiver.js
@@ -36,7 +36,7 @@ class Receiver {
    * Send Request header.
    * @type {{app: string, version:string, class:string, id:string, itemArray: import('../../types.js').TiItem[]} | null}
    */
-  #sendRequestHeader;
+  // #sendRequestHeader;
   /** @type {{class: string} & import('../../types.js').TiItem | null} */
   #recvHeader;
   /**
@@ -121,7 +121,7 @@ class Receiver {
     this.#recvBufArray = [];
     this.#recvBufArrayLen = 0;
     this.#haveParsedHeader = false;
-    this.#sendRequestHeader = null;
+    // this.#sendRequestHeader = null;
     this.#recvHeader = null;
     this.#itemFlag = 'ok';
     this.#endFlag = false;
@@ -171,7 +171,7 @@ class Receiver {
         }
         try {
           this.#recvHeader = JSON.parse(ret.header);
-        } catch (err) {
+        } catch {
           this.#setState(STATE.ERR_NETWORK);
           console.error('Header parsing error. Not JSON format.');
           this.#socket.destroy();
@@ -200,7 +200,7 @@ class Receiver {
                 throw new Error('#itemHandle is null and this should not be occur.');
               }
               await this.#itemHandle.appendFile(Buffer.concat(this.#recvBufArray));
-            } catch (err) {
+            } catch {
               // Appending to file error.
               // In this error, there is nothing tiShare can do about it.
               // Better delete what has been written so far,
@@ -258,7 +258,7 @@ class Receiver {
                 await this.#itemHandle.close();
               }
               this.#itemHandle = await fs.open(path.join(this.#recvPath, this.#itemName), 'wx');
-            } catch (err) {
+            } catch {
               // File already exists.
               // TODO Implement handling.
               // 1. Ignore the file.

--- a/src/back/task/Sender.js
+++ b/src/back/task/Sender.js
@@ -157,7 +157,7 @@ class Sender {
       }
       try {
         recvHeader = JSON.parse(ret.header);
-      } catch (err) {
+      } catch {
         this.#handleNetworkErr();
         return;
       }
@@ -352,7 +352,7 @@ class Sender {
             size: itemStat.size
           };
         }
-      } catch (err) {
+      } catch {
         // Go to next item.
         this.#goToNextItem();
         setTimeout(this.#send, 0);
@@ -385,7 +385,7 @@ class Sender {
           this.#speedBytes += chunk.byteLength;
           this.#onSendError(err);
         });
-      } catch (err) {
+      } catch {
         // Go to next item.
         this.#goToNextItem();
         setTimeout(this.#send, 0);


### PR DESCRIPTION
The `file` property had wrong path value.

The `globals` key should the direct child of `languageOptions`.
